### PR TITLE
Updates to match Bootstrap 4 usage on the main site

### DIFF
--- a/blog/posts/reflex/basics/events.md
+++ b/blog/posts/reflex/basics/events.md
@@ -3,7 +3,7 @@ title: Events
 date: 2017-09-20
 authors: dlaing
 project: reflex
-extra-css: /css/reflex/basics/grid-light.css
+extra-css: /css/reflex/basics/grid-light.css, /css/reflex/basics/events.css
 extra-js: /js/reflex/basics/reflex-basics.min.js, /js/reflex/basics/rx.all.min.js, /js/reflex/basics/rxjs-example.js
 ---
 
@@ -380,8 +380,10 @@ We'll also multiply the click count `Event`, and then add those two `Event`s tog
 
 Let's see how that goes, by clicking this two or three times:
 
-<div class="panel panel-default panel-body">
-  <button id="rxjs-button" class="btn btn-default">Click Me</button>
+<div class="card my-2">
+  <div class="card-body">
+  <button type="button" id="rxjs-button" class="btn data61-green text-white p-2 mx-2">Click Me</button>
+  </div>
 </div>
 
 Whoops!  We're seeing intermediate state - something referred to as "glitching" - where we didn't expect it.

--- a/code/.gitignore
+++ b/code/.gitignore
@@ -1,2 +1,3 @@
 dist
+dist-newstyle
 result

--- a/code/basics/css/events.css
+++ b/code/basics/css/events.css
@@ -5,3 +5,7 @@
 .fizzbuzz-pair-right {
 
 };
+
+td.layout-pair-td {
+  width: 50%;
+}

--- a/code/basics/src/Posts/Event.hs
+++ b/code/basics/src/Posts/Event.hs
@@ -345,19 +345,18 @@ layoutPair ::
   Text ->
   m a ->
   m a
-layoutPair label mLabel = do
+layoutPair label mLabel =
   el "tr" $ do
-    el "td" . el "pre" $
-      text label
-    el "td" . el "pre" $
-      mLabel
+    elClass "td" "layout-pair-td" (text label)
+    elClass "td" "layout-pair-td" mLabel
 
 wrapPairs ::
   MonadWidget t m =>
   m a ->
   m a
 wrapPairs =
-  el "table"
+  elClass "table" "table table-bordered" .
+    el "tbody"
 
 fizzBuzzPart ::
   MonadWidget t m =>

--- a/code/common/src/Util/Bootstrap.hs
+++ b/code/common/src/Util/Bootstrap.hs
@@ -17,7 +17,7 @@ button ::
   Text ->
   m (Event t ())
 button =
-  R.buttonClass "btn btn-default"
+  R.buttonClass "btn data61-green text-white p-2 mx-2"
 
 buttonClass ::
   MonadWidget t m =>
@@ -25,12 +25,12 @@ buttonClass ::
   Text ->
   m (Event t ())
 buttonClass cl =
-  R.buttonClass ("btn btn-default " <> cl)
+  R.buttonClass ("btn data61-green text-white p-2 mx-2 " <> cl)
 
 panel ::
   MonadWidget t m =>
   m a ->
   m a
 panel =
-  divClass "panel panel-default" .
-  divClass "panel-body"
+  divClass "card my-2" .
+  divClass "card-body"

--- a/code/common/src/Util/Reflex.hs
+++ b/code/common/src/Util/Reflex.hs
@@ -12,7 +12,6 @@ buttonClass :: MonadWidget t m
             -> Text
             -> m (Event t ())
 buttonClass cl label = do
-  (e, _) <- elAttr' "button" ("class" =: cl) $
+  (e, _) <- elAttr' "a" ("class" =: cl) $
              text label
   return $ domEvent Click e
-

--- a/code/grid/src/Colour.hs
+++ b/code/grid/src/Colour.hs
@@ -9,7 +9,7 @@ import qualified Data.Text as Text
 
 import Reflex.Dom.Core
 
-import Util.Reflex
+import qualified Util.Bootstrap as B
 import Util.Grid.Config
 import Util.Grid.Square
 import Util.SVG
@@ -87,7 +87,6 @@ instance Square (Colour, Colour) where
 mkRedBlueInput :: MonadWidget t m
                => m (Event t Colour)
 mkRedBlueInput = do
-  eRed <- buttonClass "btn btn-default" "Red"
-  eBlue <- buttonClass "btn btn-default" "Blue"
+  eRed <- B.button "Red"
+  eBlue <- B.button "Blue"
   return $ leftmost [Red <$ eRed, Blue <$ eBlue]
-


### PR DESCRIPTION
The styling on the main qfpl website is being updated (see https://github.com/qfpl/blog/tree/materialise-experiment). These are updates to try to ensure I don't break these posts like I did last time.

I've spot checked a couple of the posts and things seem okay.