### PR TITLE
Add Text and Lens imports in Ex11-Ex14

### DIFF
--- a/code/exercises/src/Ex11/Exercise.hs
+++ b/code/exercises/src/Ex11/Exercise.hs
@@ -6,6 +6,8 @@ module Ex11.Exercise where
 import Control.Monad.Fix (MonadFix)
 
 import Data.Text (Text)
+import qualified Data.Text as Text
+
 import qualified Data.Map as Map
 
 import Reflex

--- a/code/exercises/src/Ex12/Exercise.hs
+++ b/code/exercises/src/Ex12/Exercise.hs
@@ -5,7 +5,11 @@ module Ex12.Exercise where
 
 import Control.Monad.Fix (MonadFix)
 
+import Control.Lens
+
 import Data.Text (Text)
+import qualified Data.Text as Text
+
 import qualified Data.Map as Map
 
 import Reflex

--- a/code/exercises/src/Ex13/Exercise.hs
+++ b/code/exercises/src/Ex13/Exercise.hs
@@ -6,6 +6,8 @@ module Ex13.Exercise where
 import Control.Monad.Fix (MonadFix)
 
 import Data.Text (Text)
+import qualified Data.Text as Text
+
 import qualified Data.Map as Map
 
 import Reflex

--- a/code/exercises/src/Ex14/Exercise.hs
+++ b/code/exercises/src/Ex14/Exercise.hs
@@ -6,6 +6,8 @@ module Ex14.Exercise where
 import Control.Monad.Fix (MonadFix)
 
 import Data.Text (Text)
+import qualified Data.Text as Text
+
 import qualified Data.Map as Map
 
 import Reflex


### PR DESCRIPTION
From Exercise 11 onwards, I had to add this import to every file:
```haskell
import qualified Data.Text as Text
```

And in Exercise 12, I had to add this import:
```haskell
import Control.Lens
```

Moreover, every solution for those exercise has these imports already. I think adding these imports to the exercise skeletons would make solving them a bit more seamless.

Also, thanks for the great tutorial! It was really fun to work through.